### PR TITLE
2025_02_24_1018번_체스판_다시_칠하기

### DIFF
--- a/src/Algorithm_Study/daily/LYW/D2025_02_24_1018번_체스판_다시_칠하기.java
+++ b/src/Algorithm_Study/daily/LYW/D2025_02_24_1018번_체스판_다시_칠하기.java
@@ -1,0 +1,51 @@
+package Algorithm_Study.daily.LYW;
+
+import java.util.Scanner;
+
+public class D2025_02_24_1018번_체스판_다시_칠하기 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int N = sc.nextInt();
+        int M = sc.nextInt();
+        char[][] arr = new char[N][M];
+
+        // 입력값 배열에 넣기
+        for (int i = 0; i < N; i++) {
+            arr[i] = sc.next().toCharArray();
+        }
+
+        int answer = N*M; // 최소 다시 칠해야 하는 개수 저장
+
+        // 8x8 체스판을 선택하는 모든 경우 탐색
+        for (int i = 0; i <= N - 8; i++) {
+            for (int j = 0; j <= M - 8; j++) {
+                int cnt1 = 0; // 'W'로 시작하는 체스판과 비교
+                int cnt2 = 0; // 'B'로 시작하는 체스판과 비교
+
+                // 8x8 영역 탐색
+                for (int x = 0; x < 8; x++) {
+                    for (int y = 0; y < 8; y++) {
+                        char current = arr[i + x][j + y];
+
+                        // (x + y) 짝수 위치는 첫 번째 칸과 같은 색이어야 함
+                        if ((x + y) % 2 == 0) {
+                            if (current != 'W') cnt1++; // 'W' 시작 체스판과 비교
+                            if (current != 'B') cnt2++; // 'B' 시작 체스판과 비교
+                        } 
+                        // (x + y) 홀수 위치는 첫 번째 칸과 다른 색이어야 함
+                        else {
+                            if (current != 'B') cnt1++; // 'W' 시작 체스판과 비교
+                            if (current != 'W') cnt2++; // 'B' 시작 체스판과 비교
+                        }
+                    }
+                }
+
+                // 최소 값 갱신
+                answer = Math.min(answer, Math.min(cnt1, cnt2));
+            }
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [1018 체스판 다시 칠하기](https://www.acmicpc.net/problem/1018)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 전체 N x M 판에서 8 x 8칸을 완전탐색 하면서 확인합니다
- 8 x 8 칸에서 체스판 패턴이 아닌 부분을 체크합니다. 
(이 때, 첫번째 칸이 흰색인 경우와 검은색인 경우 두 가지로 나누어 검사합니다.)
- 두 결과 중 최소값이 최소한의 변경으로 8 x 8칸을 체스판으로 만들 수 있는 값이 됩니다.

### ⏰ 수행 시간
- 120분

### ✅ 시간 복잡도
- O(N × M)

## 💬 코드 리뷰 요청 사항
- 알고리즘 사용이 미숙하여 완전탐색으로 체스판을 검사하는 방식을 사용하였습니다. 혹시 이를 줄일 수 있는 방법 있으시면 알려주세요!
- 시간 복잡도를 아직 잘 몰라서 혹시 설명 가능하신분 구합니다..

![image](https://github.com/user-attachments/assets/42509e06-215e-4446-b70e-71b3c9111a71)
