### PR TITLE
[SJG] #0001 - 공 굴리기 문제 풀이 + 주석 추가 / [feat] 백준 11866번_요세푸스 문제 0 문제 풀이

### DIFF
--- a/src/Algorithm_Study/common/C20250228/SJG.java
+++ b/src/Algorithm_Study/common/C20250228/SJG.java
@@ -5,11 +5,13 @@ import java.util.*;
 
 public class SJG {
 	public static void main(String[] args) throws Exception {
+				// 입력을 받기 위해 BufferedReader 객체 생성
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringBuilder sb = new StringBuilder();
         // 테스트 케이스의 개수
         int T = Integer.parseInt(br.readLine());
         
+				// 테스트케이스 만큼 반복
         for(int tc = 1; tc <= T; tc++) {
             // N*N 2차원 배열의 크기
             int N = Integer.parseInt(br.readLine());

--- a/src/Algorithm_Study/daily/SJG/D20250227.java
+++ b/src/Algorithm_Study/daily/SJG/D20250227.java
@@ -1,0 +1,34 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+
+public class D20250227 {
+	public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        sb.append('<');
+        
+        String[] input = br.readLine().split(" ");
+        int N = Integer.parseInt(input[0]);
+        int K = Integer.parseInt(input[1]);
+
+        List<Integer> list = new LinkedList<>();
+        for (int i = 1; i <= N; i++) list.add(i);
+
+        int idx = 0;
+
+        while (!list.isEmpty()) {
+            idx = (idx + (K - 1)) % list.size();
+            sb.append(list.remove(idx));
+
+            if (!list.isEmpty()) sb.append(", ");
+        }
+        sb.append('>');
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# 공통문제
## 📌 문제 제목
- 문제 링크: [#1 공굴리기](https://github.com/AlgoriGym-study/AlgoriGym/blob/main/src/Algorithm_Study/common/C20250228/0001_%EA%B3%B5%EA%B5%B4%EB%A6%AC%EA%B8%B0.md)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 델타배열과 최소값이 갱신될떄마다 다음 탐색할 인덱스를 변경해가며 탐색
- 완전 탐색 및 델타배열을 사용

### ⏰ 수행 시간
- 15분

### 🤙 시간 인증
-

### ✅ 시간 복잡도
- O(n^2)

## 💬 코드 리뷰 요청 사항
- 또 이번 PR 머지를 하지 않고.. 푸시를 해버려서 view file로 코드 확인해주시면 감사하겠습니다.. ㅜ
- Test.java 파일명을 변경해서 사용했습니다! 
- nnr, nnc까지 굳이 필요할까? 싶은데 제가 생각하기엔 이게 최선이라는 생각이 들었습니다. 혹시 관련하여 좋은 방안이 생각나시면 알려주시면 감사하겠습니다 :)

---
# 데일리 문제
## 📌 문제 제목
- 문제 링크: [11866 요세푸스 문제 0](https://www.acmicpc.net/problem/11866)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- LinkedList를 사용하여 해당 순번의 인덱스 원소값을 삭제
- 인덱스는 0번부터 시작하며, 또한 해당 인덱스를 삭제하면 뒤의 인덱스들이 `-1`씩 당겨지기 때문에 `K-1`을 하며 해당하는 인덱스 삭제
- 인덱스 범위를 벗어나면 안되므로 idx == list.size()일때 다시 0이 될 수 있도록 나머지 연산자를 사용하여 인덱스 관리

### ⏰ 수행 시간
- 20분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/ac37e95f-937d-4499-a292-137355e069dc)


### ✅ 시간 복잡도
- O(n^2)

## 💬 코드 리뷰 요청 사항
- 큐를 사용해서 offer와 poll을 반복하는 과정이 비효율적이라고 생각해서 LinkedList를 사용했는데 LinkedList에서 remove()메서드의 시간복잡도가 O(n)이라 while문 순회와 함께 해서 O(n^2)로 시간복잡도로 보이는데,, 뭔가 시간복잡도관점에서 개선할 수 있을 것 같으면서도 생각이 잘 나지않네용.. 흑흑