### PR TITLE
[feat] 백준 1018번_체스판 다시 칠하기 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250228.java
+++ b/src/Algorithm_Study/daily/SJG/D20250228.java
@@ -1,0 +1,45 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class D20250228 {
+	public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] inputNM = br.readLine().split(" ");
+        int N = Integer.parseInt(inputNM[0]);
+        int M = Integer.parseInt(inputNM[1]);
+        
+        char[][] arr = new char[N][M];
+        for(int i = 0; i < N; i++) {
+            char[] input = br.readLine().toCharArray();
+            for(int j = 0; j < M; j++) arr[i][j] = input[j];
+        }
+        br.close();
+        
+        int min = 64;
+        for(int i = 0; i <= N - 8; i++) {
+            for(int j = 0; j <= M - 8; j++) {
+                int wCnt = 0;
+                int bCnt = 0;
+                
+                for(int k = 0; k < 8; k++) {
+                        for(int l = 0; l < 8; l++) {
+                            char c = arr[i+k][j+l];
+                            char wStart = ((k+l) % 2 == 0) ? 'W' : 'B';
+                            char bStart = ((k+l) % 2 == 0) ? 'B' : 'W';
+                            
+                            if(c != wStart) wCnt++;
+                            if(c != bStart) bCnt++;
+                        }
+                    }
+                
+                int minCnt = (wCnt > bCnt) ? bCnt : wCnt;
+                if(min > minCnt) {
+                    min = minCnt;
+                }
+            }
+        }
+        System.out.print(min);
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 1018번_체스판 다시 칠하기](https://www.acmicpc.net/problem/1018)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 완전 탐색을 사용한 풀이
- 'W'로 시작하는 체스판일때는 짝수번째 인덱스가 'W'가 작성되어있어야 정상적인 체스판. 반대의 경우도 마찬가지.
- 문제 설명에 NM의 순서가 바뀌어있어 M*N배열이아니라 N*M배열로 풀이해야함.

### ⏰ 수행 시간
- 40분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/30e4eb90-74ab-418f-80e2-6f2152673154)


### ✅ 시간 복잡도
- O(NM)

## 💬 코드 리뷰 요청 사항
- 고려해야할 조건들이 많아 조건분기 관련해서 gpt의 도움을 받았습니다. 조건분기를 조금 더 줄일 수 있는 방법이 있을지 함꼐 고민해주시면 감사하겠습니다 :)
