### PR TITLE
[feat] 백준 2839번 설탕 배달 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250303.java
+++ b/src/Algorithm_Study/daily/SJG/D20250303.java
@@ -1,0 +1,27 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class D20250303 {
+	public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        br.close();
+        
+        int minBags = -1;
+
+        for (int i = 0; i * 5 <= N; i++) {
+            int remaining = N - (i * 5);
+            if (remaining % 3 == 0) {
+                int three = remaining / 3;
+                int totalBags = i + three;
+                if (minBags == -1 || totalBags < minBags) {
+                    minBags = totalBags;
+                }
+            }
+        }
+
+        System.out.println(minBags);
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 2839번 설탕 배달](https://www.acmicpc.net/problem/2839)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 나누기 연산자와 나머지 연산자를 사용하면 금방 풀 수 있겠다 생각했는데, 해당 연산자를 사용하다보니 5와 3으로 충분히 나머지를 0으로 만들 수 있음에도 불구하고 -1을 출력하는 이슈가 발생했습니다.
- i*5를 사용하여 5키로 설탕의 개수를 순차적으로 늘려나가며 나머지 개수를 3키로 설탕으로 채울 수 있는지 확인하는 방식으로 진행했습니다!

### ⏰ 수행 시간
- 40분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/ab657d18-ad70-4e0e-8fe6-e29737cac8a7)


### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- dp방식으로도 풀이할 수 있다고 하던데 gpt의 설명을 이해를 못했습니다,, dp에 대해서 알고 계신분이 있으시면 알려주시면 감사하겠습니다!
