### PR TITLE
[SJG] #0002 오목판정 문제 풀이

### DIFF
--- a/src/Algorithm_Study/common/C20250304/SJG.java
+++ b/src/Algorithm_Study/common/C20250304/SJG.java
@@ -1,0 +1,63 @@
+package Algorithm_Study.common.C20250304;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class SJG {
+	public static void main(String args[]) throws Exception
+	{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+       	StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+
+        // 델타 배열 (가로, 세로, 우하 대각선, 우상 대각선)
+        int[] dr = {0, 1, 1, -1};
+        int[] dc = {1, 0, 1, 1};
+        
+		for(int test_case = 1; test_case <= T; test_case++)
+		{
+			int N = Integer.parseInt(br.readLine());
+			int[][] field = new int[N][N];
+			
+			for(int i = 0; i < N; i++) {
+				char[] input = br.readLine().toCharArray();
+				for(int j = 0; j < N; j++) {
+					char c = input[j];
+					if(c == '.') field[i][j] = 0;
+					else field[i][j] = 1;
+				}
+			}
+			
+			boolean found = false;
+			outer:	// 중첩 for문을 한번에 빠져나오기 위한 label 사용
+			for (int i = 0; i < N; i++) {
+			    for (int j = 0; j < N; j++) {
+			        if (field[i][j] == 1) {
+			            for (int d = 0; d < 4; d++) {
+			                int count = 1;
+			                for (int k = 1; k < 5; k++) {
+			                    int nr = i + dr[d] * k;
+			                    int nc = j + dc[d] * k;
+
+			                   
+			                    if (nr < 0 || nr >= N || nc < 0 || nc >= N) break;
+
+			                    if (field[nr][nc] == 1) count++;
+			                    else break;
+			                }
+
+			                if (count >= 5) {
+			                    found = true;
+			                    break outer;
+			                }
+			            }
+			        }
+			    }
+			}
+
+			sb.append("#").append(test_case).append(" ").append(found ? "YES" : "NO").append("\n");
+		}
+        br.close();
+        System.out.print(sb);
+	}
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [SWEA 11315. 오목 판정](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AXaSUPYqPYMDFASQ)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- '.'부분을 0으로 'o'부분을 1로 정수형 2차원배열을 사용하여 풀이
- 왼쪽 혹은 윗쪽의 1은 이전 탐색과정에서 이미 확인했기 때문에 델타배열에서 관련 요소 제거
- [파리퇴치3 리뷰사항](https://github.com/AlgoriGym-study/AlgoriGym/pull/15) 에서 리뷰를 달며 코드 중복을 줄이는 방식 제안한 것이 생각나 해당 방식을 4중 배열에서 델타배열에 k값을 곱하며 연산하는 방식 도입.
- label을 사용하는게 알고리즘 풀이에서 좀 날먹(?)느낌이라 지양하려했는데 boolean값을 들고 다니기 귀찮아서 그냥 사용했습니다,,

### ⏰ 수행 시간
- 45분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/1b3e5aca-0f54-4e91-8b8b-9542c5bd7b4d)


### ✅ 시간 복잡도
- O(N^2)(O(N^4))

## 💬 코드 리뷰 요청 사항
- 지난번에 델타배열 없이 풀이할 때 너무 힘들었는데 델타배열에 익숙해진 후에 대각선 연산 부분에 대한 해결책을 찾을 수 있었습니다.. 오목 판정 풀이 첫 pass!
