### PR TITLE
[feat] 백준 1931 회의실 배정 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250306.java
+++ b/src/Algorithm_Study/daily/SJG/D20250306.java
@@ -1,0 +1,34 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class D20250306 {
+	public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        
+        int[][] room = new int[N][2];
+        for(int i = 0; i < N; i++) {
+            String[] input = br.readLine().split(" ");
+            room[i][0] = Integer.parseInt(input[0]);
+            room[i][1] = Integer.parseInt(input[1]);
+        }
+        
+        Arrays.sort(room, (o1, o2) -> {
+           if(o1[1] == o2[1]) return o1[0] - o2[0];
+            return o1[1] - o2[1];
+        });
+        
+        int cnt = 0;
+        int lastEndTime = 0;
+        for(int i = 0; i < N; i++) {
+            if(room[i][0] >= lastEndTime) {
+                lastEndTime = room[i][1];
+                cnt++;
+            }
+        }
+        System.out.print(cnt);
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 1931. 회의실 배정](https://www.acmicpc.net/problem/1931)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 회의 종료시간을 기점으로 오름차순 정렬을 수행 후 연산

### ⏰ 수행 시간
- 1시간 10분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/1c4e070b-afa0-4209-bc52-494a8b439f57)


### ✅ 시간 복잡도
- O(N log N)

## 💬 코드 리뷰 요청 사항
- 그리디 재미가 있네요.. 진짜임.

- 아래 이 문제도 그리디가 뭐지? 할때 풀기 괜찮았어서 남깁니당
- [구름- 통증](https://level.goorm.io/exam/195690/%ED%86%B5%EC%A6%9D/quiz/1)