### PR TITLE
[feat] 백준 15650번 N과 M (2) 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250309.java
+++ b/src/Algorithm_Study/daily/SJG/D20250309.java
@@ -1,0 +1,34 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class D20250309 {
+	static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] input = br.readLine().split(" ");
+        int N = Integer.parseInt(input[0]);
+        int M = Integer.parseInt(input[1]);
+        br.close();
+        int[] res = new int[M];
+        int[] arr = new int[N];
+        for (int i = 0; i < N; i++) arr[i] = i + 1;
+        comb(0, 0, arr, M, res, N);
+
+        System.out.print(sb);
+    }
+
+    private static void comb(int idx, int start, int[] arr, int M, int[] res, int N) {
+        if (idx == M) {
+            for (int n : res) sb.append(n).append(" ");
+            sb.append("\n");
+            return;
+        }
+        for (int i = start; i < N; i++) {
+            res[idx] = arr[i];
+            comb(idx + 1, i + 1, arr, M, res, N);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [N과 M (2)](https://www.acmicpc.net/problem/15650)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 조합을 구해야하는데 이전 숫자보다 큰 값을 선택해야합니다.
- idx와 start를 매개변수로 입력하여 이전값보다 큰 값을 다음 조합리스트로 선택하도록 했습니다.

### ⏰ 수행 시간
- 40분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/2c69ca8b-f50c-484e-8512-17f56befb4e9)


### ✅ 시간 복잡도
- O(N!) (?) -> 해당 유형의 경우 시간복잡도를 어떻게 책정해야할지.. 잘 모르겠네요 ㅜㅜ

## 💬 코드 리뷰 요청 사항
- 처음에 백트래킹문제인줄 알구 visited 사용해서 삽질을...흑흑
