### PR TITLE
[feat] 백준 1463번 1로만들기 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250310.java
+++ b/src/Algorithm_Study/daily/SJG/D20250310.java
@@ -1,0 +1,29 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class D20250310 {
+	public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        br.close();
+
+        int[] dp = new int[N + 1];
+        Arrays.fill(dp, Integer.MAX_VALUE);
+        dp[1] = 0;
+
+
+        for (int i = 2; i <= N; i++) {
+            if (i % 3 == 0) {
+                dp[i] = Math.min(dp[i], dp[i / 3] + 1);
+            }
+            if (i % 2 == 0) {
+                dp[i] = Math.min(dp[i], dp[i / 2] + 1);
+            }
+            dp[i] = Math.min(dp[i], dp[i - 1] + 1);
+        }
+        System.out.println(dp[N]);
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 1463번 1로 만들기](https://www.acmicpc.net/problem/1463)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 정수의 최대값으로 dp배열 초기화
- dp배열에서 주어진 수가 1일때부터 주어진 수 N이 될 때까지 점화식을 세워 순차적으로 채워나감
- 3으로 나눠 떨어지는 수는 이전에 3으로 나눠떨어진 수 보다 한번 더 3으로 나눠져야하기에 이전 i/3에서 +1한 값과 현재 dp[i]값을 비교하여 작은 값으로 저장. 2로 나누어떨어지는 수 및 i-1 또한 동일한 규칙 적용.
- [백준2839. 설탕배달](https://github.com/AlgoriGym-study/AlgoriGym/pull/42) 해당 문제와 규칙이 비슷한것 같아 참고해서 풀이했습니다.

### ⏰ 수행 시간
- 1시간 20분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/71a587c9-37b5-48cf-9980-1f9d73fa916a)


### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- 점화식을 세우는 것 아직은 너무 어려워요 ㅜ
