### PR TITLE
[feat] 백준15652_N과M(4) 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/YHS/D20250320_N과M_4.java
+++ b/src/Algorithm_Study/daily/YHS/D20250320_N과M_4.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class D20250320_N과M_4 {
+    static int N, M;
+    static int[] nums;
+    static int[] ans;
+    static StringBuilder sb;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        ans = new int[M];
+
+        sb = new StringBuilder();
+        perm(0, 1);
+        System.out.println(sb);
+    }
+
+    static void perm(int depth, int start) {
+        if (depth == M) {
+            for (int num : ans) {
+                sb.append(num + " ");
+            }
+            sb.append("\n");
+
+            return;
+        }
+
+        for (int i = start; i <= N; i++) {
+            ans[depth] = i;
+            perm(depth + 1, i);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준_N과M(4)](https://www.acmicpc.net/problem/15652)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- N과M(2) 에서 '비내림차순' 이라는 조건만 추가된 문제입니다.
- 재귀조건을 i + 1 이 아니라 i 로 바꿔주기만 하면 되는 간단한 문제이지만 그걸 생각하지 못해서 처음에 삽질을 좀 했습니다..

### ⏰ 수행 시간
- 15분

### 🤙 시간 인증
- 
![image](https://github.com/user-attachments/assets/16af9289-209c-4568-bac6-40a1f20ca985)


### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- 스터디 한 날이라 쉬운 문제로 풀었습니다ㅎ
