### PR TITLE
[feat] 백준 1260번 DFS와 BFS 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250324.java
+++ b/src/Algorithm_Study/daily/SJG/D20250324.java
@@ -1,0 +1,77 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.*;
+import java.util.*;
+
+class D20250324 {
+  static int N, M, V;
+  static List<Integer>[] graph;
+  static boolean[] visited;
+  static boolean found;
+  public static void main(String[] args) throws Exception {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringBuilder sb = new StringBuilder();
+        
+    String[] inputNMV = br.readLine().split(" ");
+        N = Integer.parseInt(inputNMV[0]);    // 정점의 개수
+        M = Integer.parseInt(inputNMV[1]);    // 간선의 개수
+        V = Integer.parseInt(inputNMV[2]);    // 탐색 시작 정점 번호
+        
+        graph = new ArrayList[N+1];
+        for(int i = 1; i <= N; i++) graph[i] = new ArrayList<>();
+        
+        for(int i = 0; i < M; i++) {
+            String[] input = br.readLine().split(" ");
+            int from = Integer.parseInt(input[0]);
+            int to = Integer.parseInt(input[1]);
+            
+            graph[from].add(to);
+            graph[to].add(from);
+        }
+        br.close();
+        
+        visited = new boolean[N+1];
+        StringBuilder dfsRes = new StringBuilder();
+        dfs(V, dfsRes);
+        sb.append(dfsRes.toString().trim()).append("\n");
+        
+        visited = new boolean[N+1];
+        StringBuilder bfsRes = new StringBuilder();
+        bfs(V, bfsRes);
+        sb.append(bfsRes.toString().trim());
+        System.out.print(sb);
+    }
+    
+    private static void dfs(int start, StringBuilder sb) {
+        visited[start] = true;
+        sb.append(start).append(" ");
+        
+        Collections.sort(graph[start]);
+        
+        for(int n : graph[start]) {
+            if(!visited[n]) dfs(n, sb);
+        }
+    }
+    
+    private static void bfs(int start, StringBuilder sb) {
+        Queue<Integer> q = new LinkedList<>();
+        
+        q.offer(start);
+        visited[start] = true;
+        sb.append(start).append(" ");
+        
+        while(!q.isEmpty()) {
+            int curr = q.poll();
+            
+            Collections.sort(graph[curr]);
+            
+            for(int n : graph[curr]) {
+                if(!visited[n]) {
+                    visited[n] = true;
+                    q.offer(n);
+                    sb.append(n).append(" ");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 1260번 DFS와 BFS](https://www.acmicpc.net/problem/1260)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 오늘 학습한 내용을 바탕으로 인접 리스트 방식을 사용해서 그래프를 입력했습니다.
- 추가적으로 오늘 실습문제를 풀면서 DFS와 BFS를 사용해서, 해당 학습내용을 바탕으로 DFS와 BFS를 구현하여 풀이했습니다.
- 두 메서드 내에서 정점이 여러개인 경우에 번호가 작은 곳을 먼저 방문해야하기에 메서드 내에서 정렬을 수행했고, 백트래킹을 사용하여 방문여부를 체크 했습니다.
- DFS 메서드 내에서 방문 정점을 StringBuilder 객체에 추가한 후 해당 그래프와 간선으로 연결된 다음 간선을 타고 방문하지 않은 간선들에 대해 재귀를 사용했습니다.
- BFS에서는 동일 레벨의 정점들을 저장하기 위해 q를 선언하여 관리했습니다.

### ⏰ 수행 시간
- 50분

### 🤙 시간 인증
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/0444c22a-aad1-4bf8-ab69-8dfb1f734e1e" />

### ✅ 시간 복잡도
-  O(N^2 log N + M) 이라네요 넵.. 이제 시간복잡도 계산도 어려워여,,

## 💬 코드 리뷰 요청 사항
- 오늘 학습한 내용을 바탕으로 DFS와 BFS까지 학습해서 단기기억으로 빠르게,,
