### PR TITLE
[feat] 백준 2178번 미로 탐색 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250325.java
+++ b/src/Algorithm_Study/daily/SJG/D20250325.java
@@ -1,0 +1,63 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class D20250325 {
+	static int N, M;
+    static int[][] arr;
+    static boolean[][] visited;
+    
+    static int[] dr = {-1, 1, 0, 0};
+    static int[] dc = {0, 0, -1, 1};
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] inputNM = br.readLine().split(" ");
+        N = Integer.parseInt(inputNM[0]);
+        M = Integer.parseInt(inputNM[1]);
+        
+        arr = new int[N][M];
+        visited = new boolean[N][M];
+        
+        for(int i = 0; i < N; i++) {
+            String input = br.readLine();
+            for(int j = 0; j < M; j++) arr[i][j] = input.charAt(j) - '0';
+        }
+        br.close();
+        
+        System.out.print(bfs());
+    }
+    
+    private static int bfs() {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{0, 0, 1}); // r, c, distance
+        visited[0][0] = true;
+        
+        while(!queue.isEmpty()) {
+            int[] current = queue.poll();
+            int r = current[0];
+            int c = current[1];
+            int dist = current[2];
+            
+            if(r == N-1 && c == M-1) {
+                return dist;
+            }
+            
+            for(int d = 0; d < 4; d++) {
+                int nr = r + dr[d];
+                int nc = c + dc[d];
+                
+                if(nr < 0 || nc < 0 || nr >= N || nc >= M) continue;
+                if(arr[nr][nc] == 0) continue;
+                if(visited[nr][nc]) continue;
+                
+                visited[nr][nc] = true;
+                queue.offer(new int[]{nr, nc, dist + 1});
+            }
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준2178 미로탐색](https://www.acmicpc.net/problem/2178)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- bfs를 사용하여 상하좌우를 탐색하며 방문가능한 장소가 있으면 이동하면서 dist+1을 수행하며 탈출구를 찾음

### ⏰ 수행 시간
- 1시간 30분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/6761ffda-dd7f-4079-baf1-69c646075143)


### ✅ 시간 복잡도
- O(N * M)

## 💬 코드 리뷰 요청 사항
- DFS로 풀었는데 시간초과가 떠서 금방할 줄 알았는데 흑흑
- 최단경로 문제에서는 BFS를 활용하는게 좋다고 하네요,,,
