### PR TITLE
[feat] 백준2667 단지번호붙이기 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/YHS/D20250328_단지번호붙이기.java
+++ b/src/Algorithm_Study/daily/YHS/D20250328_단지번호붙이기.java
@@ -1,0 +1,84 @@
+import java.io.*;
+import java.util.*;
+
+public class D20250328_단지번호붙이기 {
+	
+	static class Pos {
+		int x, y;
+
+		public Pos(int x, int y) {
+			this.x = x;
+			this.y = y;
+		}
+	}
+	
+	static int N, count;
+	static int[][] map;
+	static boolean[][] visit;
+	static int[] dr = {-1,1,0,0};
+	static int[] dc = {0,0,-1,1};
+	static List<Integer> ans;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		N = Integer.parseInt(br.readLine());
+		map = new int[N][N];
+		ans = new ArrayList<>();
+		visit = new boolean[N][N];
+		
+		for (int i = 0; i < N; i++) {
+			String str = br.readLine();
+			for (int j = 0; j < N; j++) {
+				map[i][j] = str.charAt(j) - '0';
+			}
+		}
+		
+		count = 0;
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < N; j++) {
+				if (map[i][j] == 1 && !visit[i][j]) {
+					bfs(i,j);
+					count++;
+				}
+			}
+		}
+		
+		System.out.println(count);
+		
+		Collections.sort(ans);
+		
+		for (int num : ans) {
+			System.out.println(num);
+		}
+	}
+	
+	static void bfs(int x, int y) {
+		Queue<Pos> q = new LinkedList<>();
+		q.add(new Pos(x,y));
+		visit[x][y] = true;
+		int num = 1;
+		
+		while (!q.isEmpty()) {
+			Pos curr = q.poll();
+			int row = curr.x;
+			int col = curr.y;
+			
+			for (int d = 0; d < 4; d++) {
+				int nr = row + dr[d];
+				int nc = col + dc[d];
+				
+				if (nr >= 0 && nr < N && nc >= 0 && nc < N) {
+					if (!visit[nr][nc] && map[nr][nc] == 1) {
+						visit[nr][nc] = true;
+						num++;
+						q.add(new Pos(nr,nc));
+					}
+				}
+			}
+		}
+		
+		ans.add(num);
+	}
+	
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 단지번호붙이기](https://www.acmicpc.net/problem/2667)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
-  BFS를 이용하여 집이 모여있는 단지를 판단하고 개수(count)를 세준 뒤 리스트에 넣어주었습니다.
- 한개 단지의 집 개수를 세고 나면 count 를 초기화해준 뒤 다시 지도를 순회하며 방문하지 않은 집들을 다시 세도록 했습니다.

### ⏰ 수행 시간
- 50분

### 🤙 시간 인증
-  
![image](https://github.com/user-attachments/assets/4378d608-329f-4dd9-89b3-0a550a85b70d)


### ✅ 시간 복잡도
- O(N^2)

## 💬 코드 리뷰 요청 사항
- 문제에서 주어진 범위가 작아서 dfs 로도 풀릴 것 같은데 다음에 다시 풀어보겠습니다!

