### PR TITLE
[feat] SWEA 파핑파핑 지뢰찾기 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250330.java
+++ b/src/Algorithm_Study/daily/SJG/D20250330.java
@@ -1,0 +1,99 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.*;
+import java.util.*;
+
+public class D20250330 {
+	static int N;
+    static char[][] field;
+    static int[][] counts;
+    static boolean[][] visited;
+     
+    static int[] dr, dc;
+     
+    public static void main(String args[]) throws Exception
+    {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+         
+        // 상, 하, 좌, 우, 좌상, 우상, 좌하, 우하
+        dr = new int[]{-1, 1, 0, 0, -1, -1, 1, 1};
+        dc = new int[]{0, 0, -1, 1, -1, 1, -1, 1};
+         
+        for(int test_case = 1; test_case <= T; test_case++)
+        {
+            N = Integer.parseInt(br.readLine());
+            field = new char[N][N];
+            visited = new boolean[N][N];
+            counts = new int[N][N];
+            for(int i = 0; i < N; i++) {
+                char[] input = br.readLine().toCharArray();
+                for(int j = 0; j < N; j++) field[i][j] = input[j];
+            }
+             
+            for(int i = 0; i < N; i++) {
+                for(int j = 0; j < N; j++) {
+                    // 지뢰일때
+                    if(field[i][j] == '*') {
+                        counts[i][j] = -1;
+                        continue;
+                    }
+                    int mineCnt = 0;
+                    for(int d= 0; d < 8; d++) {
+                        int nr = i + dr[d];
+                        int nc = j + dc[d];
+                         
+                        if(nr < 0 || nc < 0 || nr >= N || nc >= N) continue;
+                         
+                        if(field[nr][nc] == '*') mineCnt++;
+                    }
+                    counts[i][j] = mineCnt;
+                }
+            }
+            int clickCnt = 0;
+            for(int i = 0; i < N; i++) {
+                for(int j = 0; j < N; j++) {
+                    if(field[i][j] == '.' && counts[i][j] == 0 && !visited[i][j]) {
+                        clickCnt++;
+                        bfs(i, j);
+                    }
+                }
+            }
+             
+            for(int i = 0; i < N; i++) {
+                for(int j = 0; j < N; j++) {
+                    if(field[i][j] == '.' && !visited[i][j]) clickCnt++;
+                }
+            }
+            sb.append("#").append(test_case).append(" ").append(clickCnt).append("\n");
+        }
+        br.close();
+        System.out.print(sb);
+    }
+     
+    private static void bfs(int r , int c) {
+        Queue<int[]> q = new LinkedList<>();
+        visited[r][c] = true;
+        q.offer(new int[]{r, c});
+         
+        while(!q.isEmpty()) {
+            int[] curr = q.poll();
+            int currR = curr[0];
+            int currC = curr[1];
+             
+            for(int d = 0; d < 8; d++) {
+                int nr = currR + dr[d];
+                int nc = currC + dc[d];
+                 
+                if(nr < 0 || nc < 0 || nr >= N || nc >= N) continue;
+                if(visited[nr][nc] || field[nr][nc] == '*') continue;
+                 
+                visited[nr][nc] = true;
+                if(counts[nr][nc] == 0) {   
+                    q.offer(new int[]{nr, nc});
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [SWEA 1868. 파핑파핑 지뢰찾기](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV5LwsHaD1MDFAXc)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 델타배열을 활용한 완전 탐색을 사용하여 해당 인덱스 주변의 지뢰의 갯수를 찾아서 counts배열에 값 할당
- 방문하지 않고, 지뢰가 아닌, 그리고 주변에 지뢰가 0개인 필드에서 bfs를 사용하여 탐색, 방문하지 않고 지뢰가 아닌 필드인지 확인 하며 탐색
- 나머지 지뢰가 아니면서 방문하지 않은 곳들을 클릭++

### ⏰ 수행 시간
- 1시간 10분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/1004e57f-f046-4ed1-9068-354175fda48f)


### ✅ 시간 복잡도
- O(N^2)

## 💬 코드 리뷰 요청 사항
- 클릭했을 때 0이 아닌 필드들을 클릭하는 조건을 놓쳐서 헤메다가 gpt의 도움을 받았습니다,,, 조건 찾기 어렵네용,,
