### PR TITLE
[feat] 백준2178_미로 탐색 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/CSY/D20250331.java
+++ b/src/Algorithm_Study/daily/CSY/D20250331.java
@@ -1,0 +1,68 @@
+package Algorithm_Study.daily.CSY;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class D20250331 {
+
+
+        static int N, M;
+        static char[][] arr;
+        static int[][] dist;
+
+        static int[] dr = {-1, 1, 0, 0};
+        static int[] dc = {0, 0, -1, 1};
+
+        public static void main(String[] args) {
+            Scanner sc = new Scanner(System.in);
+
+            N = sc.nextInt();
+            M = sc.nextInt();
+
+            arr = new char[N][M];
+            dist = new int[N][M];
+
+            for(int i = 0; i < N; i++) {
+                arr[i] = sc.next().toCharArray();
+            }
+            int ans = 0;
+            i : for(int i = 0; i < N; i++) {
+                for(int j = 0; j < M; j++) {
+                    if(arr[i][j] == '1') {
+                        ans = bfs(i, j);
+                        break i;
+                    }
+                }
+            }
+
+            System.out.println(ans);
+
+        }
+
+        static int bfs(int r, int c) {
+            Queue<int[]> q = new LinkedList<>();
+            dist[r][c] = 1;
+            q.add(new int[] {r,c});
+
+            while(!q.isEmpty()) {
+
+                int[] cur = q.poll();
+                if(cur[0] == N - 1 && cur[1] == M-1) return dist[cur[0]][cur[1]];
+                for(int d = 0; d < 4; d++) {
+                    int nr = cur[0] + dr[d];
+                    int nc = cur[1] + dc[d];
+
+                    if(nr < 0 || nr >= N || nc < 0 || nc >= M) continue;
+                    if(arr[nr][nc] == '0' || dist[nr][nc] != 0) continue;
+
+                    arr[nr][nc] = '0';
+                    dist[nr][nc] = dist[cur[0]][cur[1]] + 1;
+                    q.add(new int[] {nr, nc});
+                }
+            }
+
+            return -1;
+        }
+
+
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [미로탐색](https://www.acmicpc.net/problem/2178)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- bfs 방식으로 풀었습니다. 
- 방문 배열 대신 지나간 곳은 0으로 바꿔서 탐색하지 않도록 하였습니다.

### ⏰ 수행 시간
- 40분 

### 🤙 시간 인증
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/35670219-907d-4c43-bc8a-1873cb55ff0e" />


### ✅ 시간 복잡도
- O(N*M)

## 💬 코드 리뷰 요청 사항
- 내일 스터디도 파이팅~~ 
