### PR TITLE
[feat] 백준 1697번 숨바꼭질 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250403.java
+++ b/src/Algorithm_Study/daily/SJG/D20250403.java
@@ -6,9 +6,9 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 public class D20250403 {
-    static int N, K;
-    static final int MAX_SPOT = 100_001;
-    static int[] time;
+    static int N, K; // N: 시작 위치, K: 목표 위치
+    static final int MAX_SPOT = 100_001;  // 최대 위치 -> 0 ~ 100_000
+    static int[] time; // 각 위치에 도달하는 최소 시간
     
     public static void main(String[] args) throws Exception {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
@@ -46,7 +46,7 @@ public class D20250403 {
             for(int next : nextList) {
                 if(next >= 0 && next < MAX_SPOT) {
                     if(time[next] == -1) {
-                        time[next] = time[curr] + 1;
+                        time[next] = time[curr] + 1;  // 다음 위치에 도달하는 최소 시간
                         q.offer(next);
                     }
                 }


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 1697번 숨바꼭질](https://www.acmicpc.net/problem/1697)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 상수 MAX_SPOT을 최대 범위인 100,000에서 +1 하여 100,001로 초기화한 다음 방문여부를 저장할 time배열의 크기로 초기화. 이후 전체 값을 -1로 초기화
- 출발지에서 부터 bfs를 탐색하며, {X-1, X+1, X*2}배열을 생성하여 해당 리스트를 순회.

### ⏰ 수행 시간
- 1시간 10분

### 🤙 시간 인증
<img width="1135" alt="image" src="https://github.com/user-attachments/assets/45745cd5-0c7e-4e93-83b9-cdf0872948c1" />


### ✅ 시간 복잡도
- O(100001)

## 💬 코드 리뷰 요청 사항
- X-1, X+1, X*2부분을 처리하는 부분에 있어서 배열로 구현할 생각을 못했는데 GPT의 조언을 더해서 풀 수 있었어요,, 
