### PR TITLE
[feat] 백준 25501 재귀의 귀재 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/CSY/April/D20250408_재귀의귀재.java
+++ b/src/Algorithm_Study/daily/CSY/April/D20250408_재귀의귀재.java
@@ -1,0 +1,37 @@
+package Algorithm_Study.daily.CSY.April;
+
+
+    import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class D20250408_재귀의귀재 {
+        public static int recursion(String s, int l, int r){
+            cnt++;
+            if(l >= r) return 1;
+            else if(s.charAt(l) != s.charAt(r)) return 0;
+            else return recursion(s, l+1, r-1);
+        }
+
+
+        public static int isPalindrome(String s){
+            return recursion(s, 0, s.length()-1);
+        }
+
+        static int cnt;
+        public static void main(String[] args) throws NumberFormatException, IOException{
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            int N = Integer.parseInt(br.readLine());
+            StringBuilder st = new StringBuilder();
+            for(int i = 0; i < N; i++) {
+                cnt = 0;
+                String str = br.readLine();
+                int ans = isPalindrome(str);
+                st.append(ans).append(" ").append(cnt).append("\n");
+            }
+            System.out.println(st.toString());
+
+
+        }
+    }


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [재귀의 귀재](https://www.acmicpc.net/problem/25501)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 문제에 있는 재귀함수를 이용했고, 카운트만 스테틱 선언해서 풀었습니다.

### ⏰ 수행 시간
- 20분 

### 🤙 시간 인증
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/babc2df0-9e83-43f1-8b44-535a1f4dac6c" />


### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- 회문도 재귀로 가능했군요...!!! 재귀 연습하려고 문제들 보다가 회문을 푸는 방법 중 스트링빌더의 리버스 말고도 있다는 것에 풀어보았습니다!!
