### PR TITLE
[feat] 백준 알파벳 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/YHS/D20250408_알파벳.java
+++ b/src/Algorithm_Study/daily/YHS/D20250408_알파벳.java
@@ -1,0 +1,48 @@
+package Algorithm_Study.daily.YHS;
+
+import java.io.*;
+import java.util.*;
+
+public class D20250408_알파벳 {
+    static int R, C, max;
+    static char[][] board;
+    static Set<Character> set = new HashSet<>();
+    static int[] dr = { -1, 1, 0, 0 };
+    static int[] dc = { 0, 0, -1, 1 };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        R = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+        max = Integer.MIN_VALUE;
+
+        board = new char[R][C];
+
+        for (int i = 0; i < R; i++) {
+            board[i] = br.readLine().toCharArray();
+        }
+
+        set.add(board[0][0]);
+        dfs(0, 0, 1);
+        System.out.println(max);
+    }
+
+    static void dfs(int r, int c, int count) {
+       max = Math.max(max, count);
+
+       for (int d = 0; d < 4; d++) {
+            int nr = r + dr[d];
+            int nc = c + dc[d];
+
+            if (nr < 0 || nr >= R || nc < 0 || nc >= C) continue;
+
+            if (set.contains(board[nr][nc])) continue;
+
+            set.add(board[nr][nc]);
+            dfs(nr,nc,count+1);
+            set.remove(board[nr][nc]);
+       }
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준_알파벳](https://www.acmicpc.net/problem/1987)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- bfs 에 비해 dfs 는 좀 미숙한것 같아 dfs 문제들 위주로 풀어보는 중입니다.
- 오랜만에 백트래킹을 하려니 또 모르겠네요.. 

### ⏰ 수행 시간
- 30분

### 🤙 시간 인증
- 
![image](https://github.com/user-attachments/assets/47b352c2-f741-4d15-a792-e4ca1b634f03)


### ✅ 시간 복잡도
- 최악의 경우 O(26!) ...

## 💬 코드 리뷰 요청 사항
- 생각보다 실행시간이 엄청 오래걸려서 다른 사람들 코드를 보니 거의 대부분이 비트 마스킹으로 풀었더라구요
- 하지만 전 할줄 모르니 깔끔하게 포기 ~

```
비트 마스킹 방식 (int)
알파벳은 총 26자 → 정수형(int)의 26비트로 표현 가능

'A' ~ 'Z'를 각각 비트 하나에 매핑

알파벳 사용 여부 확인 → 비트 연산으로 매우 빠르게 수행
``` 
라고 하네요
