### PR TITLE
[feat] 백준 1074번 Z 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250409.java
+++ b/src/Algorithm_Study/daily/SJG/D20250409.java
@@ -1,0 +1,42 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.*;
+import java.util.*;
+
+public class D20250409 {
+	static int N, size, r, c;
+    static int ans;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] input = br.readLine().split(" ");
+        
+        N = Integer.parseInt(input[0]);
+        r = Integer.parseInt(input[1]);
+        c = Integer.parseInt(input[2]);
+        
+        ans = 0;
+        size = 1 << N;
+        recur(r, c, size);
+        
+        System.out.print(ans);
+    }
+    
+    private static void recur(int r, int c, int size) {
+        if(size == 1) return;
+        
+        int halfSize = size / 2;
+        int quadSize = halfSize * halfSize;
+        if(r < halfSize && c < halfSize) {    // 1사분면
+            recur(r, c, halfSize);
+        } else if(r < halfSize && c >= halfSize) {    // 2사분면
+            ans += quadSize;
+            recur(r, c - halfSize, halfSize);
+        } else if(r >= halfSize && c < halfSize) {    // 3사분면
+            ans += 2 * quadSize;
+            recur(r - halfSize, c, halfSize);
+        } else {    // 4사분면
+            ans += 3 * quadSize;
+            recur(r - halfSize, c - halfSize, halfSize);
+        }
+    }
+}

--- a/src/Algorithm_Study/daily/SJG/D20250410.java
+++ b/src/Algorithm_Study/daily/SJG/D20250410.java
@@ -1,0 +1,81 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.*;
+import java.util.*;
+
+public class D20250410 {
+	static class Node {
+		int idx, weight;
+		public Node(int idx, int weight) {
+			this.idx = idx;
+			this.weight = weight;
+		}
+	}
+
+	static int V, E, K;
+	static List<Node>[] adj;
+	static int[] dist;
+	static final int INF = Integer.MAX_VALUE;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		String[] inputVE = br.readLine().split(" ");
+		V = Integer.parseInt(inputVE[0]);
+		E = Integer.parseInt(inputVE[1]);
+		K = Integer.parseInt(br.readLine());
+
+		adj = new ArrayList[V+1];
+		for(int i = 1; i <= V; i++) adj[i] = new ArrayList<>();
+
+		dist = new int[V+1];
+		for(int i = 0; i < V+1; i++) dist[i] = INF;
+		dist[K] = 0;
+	
+		for(int i = 0; i < E; i++) {
+			String[] input = br.readLine().split(" ");
+			int from = Integer.parseInt(input[0]);
+			int to = Integer.parseInt(input[1]);
+			int w = Integer.parseInt(input[2]);
+			adj[from].add(new Node(to, w));
+		}
+		
+		dijkstra(K);
+	
+		for (int i = 1; i <= V; i++) {
+			if (dist[i] == INF) {
+				sb.append("INF").append('\n');
+			} else {
+				sb.append(dist[i]).append('\n');
+			}
+		}
+		System.out.print(sb);
+		br.close();
+	}
+		    
+	private static void dijkstra(int startNode) {
+		dist[startNode] = 0;
+		        
+		Queue<Node> pq = new PriorityQueue<>((n1, n2) -> {
+			return n1.weight - n2.weight;
+		});
+		pq.offer(new Node(startNode, 0));
+		
+		while(!pq.isEmpty()) {
+			Node curr = pq.poll();
+			int currIdx = curr.idx;
+			int currWeight = curr.weight;
+			
+			if(currWeight > dist[currIdx]) continue;
+			for (Node neighborNode : adj[currIdx]) {
+				int neighborIdx = neighborNode.idx;
+				int edgeWeight = neighborNode.weight;
+				
+				if (dist[currIdx] + edgeWeight < dist[neighborIdx]) {
+					dist[neighborIdx] = dist[currIdx] + edgeWeight;
+					pq.offer(new Node(neighborIdx, dist[neighborIdx]));
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 1074번 Z](https://www.acmicpc.net/problem/1074)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 재귀를 통한 분할정복방식을 사용하여 풀이했습니다.
- 목표 인덱스의 r, c 값으로 해당하는 사분면의 위치를 구한 후 더이상 사분면으로 나눌 수 없을 때까지 재귀를 통해 연산이 수행되도록 했습니다.
- 2차원 배열을 생성하지 않고 사분면의 크기를 통해 방문 횟수를 연산했습니다.

### ⏰ 수행 시간
- 1시간 30분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/b8b1dbac-0504-4427-83bf-5dd29ab872cb)


### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- 2차원 배열을 생성해서 count++를 하면서 풀었는데 사분면의 크기를 가지고 연산을 통해서 2차원배열을 생성하지 않아도 되는 방법을 gpt에게 배웠습니다,, 
- 접근방식에 대해서는 예전보다 잘 생각해내는거같은데 코드로 옮기는게 힘드네요 흑흑
