### PR TITLE
[feat] 백준 2579번 계단 오르기 문제 풀이 & 백준 1541번 잃어버린 괄호 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/SJG/D20250416_1.java
+++ b/src/Algorithm_Study/daily/SJG/D20250416_1.java
@@ -1,0 +1,25 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.*;
+import java.util.*;
+
+public class D20250416_1 {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        
+        int[] score = new int[N+1];
+        int[] dp = new int[N+1];
+        for(int i = 1; i <= N; i++) score[i] = Integer.parseInt(br.readLine());
+        dp[1] = score[1];
+        if(N > 1) dp[2] = score[1] + score[2];
+        // 두칸 점프했을때, -3계단을 밟고, 이전계단과 현재 계단을 밟을때(연속된 세칸의 계단을 밟을 수 없기 때문)
+        for(int i = 3; i <= N; i++) {
+            dp[i] = Math.max(dp[i-2] + score[i], dp[i-3] + score[i-1] + score[i]);
+        }
+        
+        System.out.print(dp[N]);
+        br.close();
+    }
+}

--- a/src/Algorithm_Study/daily/SJG/D20250416_2.java
+++ b/src/Algorithm_Study/daily/SJG/D20250416_2.java
@@ -1,0 +1,23 @@
+package Algorithm_Study.daily.SJG;
+
+import java.io.*;
+
+public class D20250416_2 {
+  public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] input = br.readLine().split("-");
+        int minSum = calc(input[0]);
+        
+        for(int i = 1; i< input.length; i++) minSum -= calc(input[i]);
+        
+        System.out.print(minSum);
+        br.close();
+    }
+    
+    private static int calc(String part) {
+        int sum = 0;
+        String[] num = part.split("\\+");
+        for(String str : num) sum += Integer.parseInt(str);
+        return sum;
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 2579번 계단오르기](https://www.acmicpc.net/problem/2579)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 일단 배열 score에 각 계단 수만큼의 점수를 할당했습니다.
- dp 배열도 score배열의 길이와 똑같이 셋팅했습니다.
- 첫번째 계단은 무조건 밟을때가 최대값이기 때문에 dp[1]값을 첫번째 계단의 점수인 score[1]의 값으로 초기설정했습니다.
- N이 1초과일때 dp[2]부터 셋팅할 수 있기 때문에 해당 조건 충족시 2번째 계단까지는 3번의 연속된 계단을 밟는 조건에 걸리지 않기 때문에 score[1] + score[2]의 값을 dp[2]에 셋팅했습니다.
- dp[3]부터는 두칸을 점프해서 해당 칸에 도착했을때와, 이전 -3인덱스의 계단을 밟고 -> 2칸점프하여 -1인덱스의 계단을 밟고, 현재 계단을 밟았을 때. 두 개의 경우의 수를 비교하여 max값을 저장을 했습니다.
- 해당 점화식을 사용하여 dp[N]일때 현재 계단까지 오기까지의 최대 점수값을 bottom-up방식으로 구할 수 있었습니다.

### ⏰ 수행 시간
- 40분

### 🤙 시간 인증
<img width="679" alt="image" src="https://github.com/user-attachments/assets/2f652126-197f-4dbf-b622-bca075e5eec5" />

### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- 어제 풀다가.. 잠깐 침대의 유혹에 응했는데,,, 눈뜨니까 다음날..하하 500원도 보내겠습니다..

---
## 📌 문제 제목
- 문제 링크: [백준 1541번 잃어버린 괄호](https://www.acmicpc.net/problem/1541)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 최적의 방식을 찾아야 하기 때문에 그리디 방식을 채택해서 풀이했습니다.
- 더할 수 있는 값을 모두 더 하고 뺄셈을 마지막에 수행했을때 최소합이 나오는 규칙을 찾아서 해당 방안대로 로직을 작성했습니다.
- '-'기호를 기준으로 `split()`을 진행한 후 첫번째 요소내의 숫자들의 합을 구한 후 출력할 값 minSum에 할당하여 초기화 했습니다.
- 그 다음부터 input.length만큼 순회하며, 다음 인덱스에 위치한 숫자값들을 모두 더해준 후 minSum에서 뺄셈을 해주면서 문제해결을 수행했습니다.

### ⏰ 수행 시간
- 50분

### 🤙 시간 인증
<img width="679" alt="image" src="https://github.com/user-attachments/assets/ac20e558-911a-47dc-a02b-f5726e76bb69" />

### ✅ 시간 복잡도
- O(N)

## 💬 코드 리뷰 요청 사항
- DP도 Greedy도 규칙같은것을 찾는게 힘드네요 흑흑..
