### PR TITLE
[SJG] #0016 뿌요뿌요 문제풀이 & #0017 최대상금 문제풀이

### DIFF
--- a/src/Algorithm_Study/common/C20250422/SJG.java
+++ b/src/Algorithm_Study/common/C20250422/SJG.java
@@ -1,0 +1,144 @@
+package Algorithm_Study.common.C20250422;
+
+import java.io.*;
+import java.util.*;
+
+public class SJG {
+	static final int ROWS = 12;
+    static final int COLS = 6;
+    static char[][] field = new char[ROWS][COLS];
+    static boolean[][] visited; // BFS 방문 체크 배열
+    
+    
+    static int[] dr = {-1, 1, 0, 0}; // 상하좌우 행 이동
+    static int[] dc = {0, 0, -1, 1}; // 상하좌우 열 이동
+
+    // 좌표를 저장하기 위한 내부 클래스 
+    static class Puyo {
+        int r, c;
+
+        Puyo(int r, int c) {
+            this.r = r;
+            this.c = c;
+        }
+
+        // Set에서 중복 제거 및 비교를 위해 hashCode와 equals 구현
+        @Override
+        public int hashCode() {
+            return r * 31 + c;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null || getClass() != obj.getClass()) return false;
+            Puyo other = (Puyo) obj;
+            return r == other.r && c == other.c;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        for (int i = 0; i < ROWS; i++) {
+            char[] input = br.readLine().toCharArray();
+            for (int j = 0; j < COLS; j++) {
+                field[i][j] = input[j];
+            }
+        }    // 입력끝
+
+        int count = 0; // 연쇄 횟수
+
+        while (true) {
+            visited = new boolean[ROWS][COLS]; // 매 연쇄마다 방문 배열 초기화
+            Set<Puyo> popCandidates = new HashSet<>(); // 터뜨릴 뿌요 좌표 저장 (Set으로 중복 방지)
+            boolean didPop = false; // 이번 턴에 터뜨렸는지 여부
+
+            // 1. 터뜨릴 수 있는 뿌요 그룹 찾기
+            for (int i = 0; i < ROWS; i++) {
+                for (int j = 0; j < COLS; j++) {
+                    if (field[i][j] != '.' && !visited[i][j]) {
+                        List<Puyo> group = bfs(i, j); // BFS 탐색
+                        if (group.size() >= 4) {
+                            popCandidates.addAll(group); // 터뜨릴 후보에 추가
+                            didPop = true;
+                        }
+                    }
+                }
+            }
+
+            // 2. 터뜨릴 뿌요가 없으면 종료
+            if (!didPop) {
+                break;
+            }
+
+            // 3. 연쇄 증가 및 뿌요 터뜨리기
+            count++;
+            for (Puyo p : popCandidates) {
+                field[p.r][p.c] = '.';
+            }
+
+            // 4. 떨어뜨리기 적용
+            applyFall();
+        }
+
+        // 최종 연쇄 횟수 출력
+        System.out.print(count);
+    }
+
+    static List<Puyo> bfs(int r, int c) {
+        Queue<Puyo> queue = new LinkedList<>();
+        List<Puyo> groupCoords = new ArrayList<>();
+        char color = field[r][c];
+
+        Puyo start = new Puyo(r, c);
+        queue.offer(start);
+        groupCoords.add(start);
+        visited[r][c] = true;
+
+        while (!queue.isEmpty()) {
+            Puyo curr = queue.poll();
+
+            for (int i = 0; i < 4; i++) {
+                int nr = curr.r + dr[i];
+                int nc = curr.c + dc[i];
+
+                // 필드 범위 체크
+                if (nr < 0 || nr >= ROWS || nc < 0 || nc >= COLS) {
+                    continue;
+                }
+
+                // 방문 여부 및 같은 색 체크
+                if (!visited[nr][nc] && field[nr][nc] == color) {
+                    visited[nr][nc] = true;
+                    Puyo next = new Puyo(nr, nc);
+                    queue.offer(next);
+                    groupCoords.add(next);
+                }
+            }
+        }
+        return groupCoords;
+    }
+
+    // 중력 함수: 뿌요 떨어뜨리기
+    static void applyFall() {
+        for (int c = 0; c < COLS; c++) {
+            Queue<Character> tempCol = new LinkedList<>(); // 각 열의 뿌요 임시 저장
+            // 열의 아래부터 위로 탐색하며 뿌요를 큐에 추가
+            for (int r = ROWS - 1; r >= 0; r--) {
+                if (field[r][c] != '.') {
+                    tempCol.offer(field[r][c]);
+                }
+            }
+
+            // 열의 아래부터 위로 다시 채우기
+            for (int r = ROWS - 1; r >= 0; r--) {
+                if (!tempCol.isEmpty()) {
+                    field[r][c] = tempCol.poll();
+                } else {
+                    field[r][c] = '.';
+                }
+            }
+        }
+    }
+}

--- a/src/Algorithm_Study/common/C20250424/SJG.java
+++ b/src/Algorithm_Study/common/C20250424/SJG.java
@@ -1,0 +1,73 @@
+package Algorithm_Study.common.C20250424;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+
+public class SJG {
+  static int N, K, NLEN;  // N: 숫자, K: 교환횟수, NLEN: N의 자릿수
+	static Set<Integer>[] visited;  // visited[i]: i번째 교환횟수에서 방문한 숫자들 -> 중복 방지
+  static int maxNum;  // 최대 숫자 -> 출력할 변수
+    
+	public static void main(String args[]) throws Exception
+	{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+        
+		for(int test_case = 1; test_case <= T; test_case++)
+		{
+			String[] input = br.readLine().split(" ");
+            N = Integer.parseInt(input[0]);
+            K = Integer.parseInt(input[1]);
+			      NLEN = String.valueOf(N).length();
+            if (NLEN < 2) {
+ 			        maxNum = N;
+			        return;
+            } // 자릿수가 1이면 교환할 필요 없음
+            visited = new HashSet[K + 1]; // visited[0]은 사용 안함
+			      for (int i = 0; i <= K; i++) visited[i] = new HashSet<>();
+            maxNum = 0; // maxNum 초기화
+            dfs(0, N); // 깊이 우선 탐색 시작
+            sb.append("#").append(test_case).append(" ").append(maxNum).append("\n");
+		}
+        System.out.print(sb);
+        br.close();
+	}
+    
+    private static void dfs(int depth, int num) {
+        // 교환횟수 달성 시 종료
+        if(depth == K) {
+            maxNum = maxNum > num ? maxNum : num;
+            return;
+        }
+        
+        // 교환횟수 미달성 시
+        for(int i = 0; i < NLEN; i++) {
+          for (int j = i + 1; j < NLEN; j++) {
+              // i와 j의 자리를 교환                  
+              int next = swap(num, i, j);
+              // 교환 후 숫자가 유효한지 확인
+              // 이미 방문한 숫자이거나 교환 후 0을 반환 받으면 맨 앞자리가 0이므로 무시
+              if (next == -1 || visited[depth + 1].contains(next))
+                continue;
+              // 교환 후 숫자가 유효하면 방문 처리
+              visited[depth + 1].add(next);
+              // 다음 깊이로 이동
+              dfs(depth+1, next);
+            }
+        }
+    }
+    
+    private static int swap(int num, int i, int j) {
+      char[] chars = String.valueOf(num).toCharArray();
+      // i와 j의 자리를 교환
+    	char tmp = chars[i];
+	    chars[i] = chars[j];
+    	chars[j] = tmp;
+        // 맨 앞자리가 0이면 무시 (자릿수 줄어드는 거 방지)
+	    if (chars[0] == '0') return -1;
+    	return Integer.parseInt(new String(chars));
+	}
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [백준 11559번 뿌요뿌요](https://www.acmicpc.net/problem/11559)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 전체 필드 순회하며 각 위치에서 BFS 수행
- 델타배열을 사용하여 상하좌우 탐색 후 같은 색일때 count 후 4칸 이상일때 set에 추가
- 터뜨린 곳은 .로 바꾸고 아래로 떨어지도록 열탐색 후 queue에 .가 아닌 값을 담고 아래서부터 q값을 Poll()
- q가 비었을때 남은 열에 . 으로 채워줌
- 반복

### ⏰ 수행 시간
- 1시간 10분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/fb60a35f-0dde-4f42-a014-b2660d7497f5)


### ✅ 시간 복잡도
- O(K * 72^2)

## 💬 코드 리뷰 요청 사항
- ~~A형.. 그냥 남아서 저녁먹는 사람 하겠습니다~~
- 진짜 남아서 저녁만 먹었음. 뭔가 코드리뷰를 안해서 해당 PR에 함께 업로드했습니다//

---

## 📌 문제 제목
- 문제 링크: [SWEA 1244. 최대상금](https://swexpertacademy.com/main/code/problem/problemDetail.do?contestProbId=AV15Khn6AN0CFAYD)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 중복조합을 제거하기 위해 백트래킹과 더불어 set자료구조로 관리
- dfs를 사용하여 교환가능한 수만큼 교환할때까지 순회
- 중첩반복문을 사용하여 교환 가능한 모든 경우의 수를 구하기 위한 탐색
- i, j인덱스를 swap메서드를 활용하여 자리 교환
- swap한 결과의 수가 이미 교환한 이력이 있거나 맨 앞자리가 0이라서 교환을 수행하지 못하면 continue;
- 위의 조건에 부합할 시 visited배열의 set에 추가 후 depth+1과 swap한 결과의 수를 dfs의 매개변수로 담아서 반복 수행

### ⏰ 수행 시간
- 30분

### 🤙 시간 인증
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/1647ede9-ce23-48a9-9979-1279a080543b" />


### ✅ 시간 복잡도
- O((L*(L-1)/2)^K) <- 최악의 경우.. 
- O(K * 조합가능한 수) <- 보통의 경우..

## 💬 코드 리뷰 요청 사항
- 안녕하세요 알고리짐 스터디 벌금파티의 다크호스. 괴물 신인. 신흥 강자. 떠오르는 샛별 서재곤입니다. 반갑습니다,,,ㅜㅜ
- 내일은 제가 없지만,, 화이팅/ 주석 열심히 달아뒀어요 그래서

