### PR TITLE
[feat] 백준 2309 일곱 난쟁이 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/LYW/D2025_04_22_백준2309_일곱난쟁이.java
+++ b/src/Algorithm_Study/daily/LYW/D2025_04_22_백준2309_일곱난쟁이.java
@@ -1,0 +1,47 @@
+package Algorithm_Study.daily.LYW;
+
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class D2025_04_22_백준2309_일곱난쟁이 {
+    static int[] dwarf = new int[9];
+    static int[] selected = new int[7];
+    static boolean found = false;
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        // 9명의 키 입력
+        for (int i = 0; i < 9; i++) {
+            dwarf[i] = sc.nextInt();
+        }
+
+        comb(0, 0);
+    }
+
+    // 조합: idx = 현재 뽑을 위치, start = 현재 선택할 인덱스
+    static void comb(int idx, int start) {
+        if (found) return;  // 이미 찾았으면 더 안 봐도 됨
+
+        if (idx == 7) {  // 7명 뽑았을 때
+            int sum = 0;
+            for (int i = 0; i < 7; i++) {
+                sum += selected[i];
+            }
+            if (sum == 100) {  // 합이 100이면 출력
+                Arrays.sort(selected);  // 오름차순 정렬
+                for (int i = 0; i < 7; i++) {
+                    System.out.println(selected[i]);
+                }
+                found = true;  // 찾았음을 표시
+            }
+            return;
+        }
+
+        // 조합으로 7명을 뽑는 부분
+        for (int i = start; i < 9; i++) {
+            selected[idx] = dwarf[i];
+            comb(idx + 1, i + 1);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [일곱 난쟁이](https://www.acmicpc.net/problem/2309)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 결국 7명의 키 합이 100이 되는 경우를 찾으면 되는 문제여서
- 부분집합을 활용해서 풀었습니다

### ⏰ 수행 시간
- 30분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/3b93c275-cb03-4636-994b-442232052b55)

### ✅ 시간 복잡도
- O(1)

## 💬 코드 리뷰 요청 사항
- 시험 화이팅!
