### PR TITLE
[feat] 백준 10163 색종이 문제 풀이

### DIFF
--- a/src/Algorithm_Study/daily/LYW/D2025_04_25_백준10163_색종이.java
+++ b/src/Algorithm_Study/daily/LYW/D2025_04_25_백준10163_색종이.java
@@ -1,0 +1,41 @@
+package Algorithm_Study.daily.LYW;
+
+import java.util.Scanner;
+
+public class D2025_04_25_백준10163_색종이 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int N = sc.nextInt();
+        int[][] paper = new int[101][101];  // 도화지 100x100
+
+        for (int n = 1; n <= N; n++) {
+            int x = sc.nextInt();
+            int y = sc.nextInt();
+            int w = sc.nextInt();
+            int h = sc.nextInt();
+
+            // 색종이 붙이기 (번호로 채우기)
+            for (int i = x; i < x + w; i++) {
+                for (int j = y; j < y + h; j++) {
+                    paper[i][j] = n;
+                }
+            }
+        }
+
+        // 각 색종이 별 넓이 계산
+        for (int n = 1; n <= N; n++) {
+            int count = 0;
+            for (int i = 0; i <= 100; i++) {
+                for (int j = 0; j <= 100; j++) {
+                    if (paper[i][j] == n) {
+                        count++;
+                    }
+                }
+            }
+            System.out.println(count);
+        }
+
+        sc.close();
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [색종](https://www.acmicpc.net/problem/10163)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 도화지에 색종이 번호를 덮어쓰며 저장 → 겹칠 경우 가장 마지막 색종이 번호로 덮어씀
- 배열을 순회하며 각 색종이 번호가 차지하는 칸 수(넓이)를 계산

### ⏰ 수행 시간
- 30

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/3cefa58b-a1fc-4e54-bf33-674295e015a7)

### ✅ 시간 복잡도
- O(N × 10,000)

## 💬 코드 리뷰 요청 사항
- 다음주 평가도 화이팅입니다!
