### PR TITLE
[feat] 백준 2628 종이자르기 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/LYW/D2025_04_27_백준2628_종이자르기.java
+++ b/src/Algorithm_Study/daily/LYW/D2025_04_27_백준2628_종이자르기.java
@@ -1,0 +1,50 @@
+package Algorithm_Study.daily.LYW;
+
+import java.util.*;
+
+public class D2025_04_27_백준2628_종이자르기 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int width = sc.nextInt();  // 가로 길이 (M)
+        int height = sc.nextInt(); // 세로 길이 (N)
+        int cuts = sc.nextInt();   // 절단 횟수
+
+        List<Integer> horizontalCuts = new ArrayList<>();
+        List<Integer> verticalCuts = new ArrayList<>();
+
+        horizontalCuts.add(0); // 시작점
+        horizontalCuts.add(height); // 끝점
+        verticalCuts.add(0);
+        verticalCuts.add(width);
+
+        for (int i = 0; i < cuts; i++) {
+            int dir = sc.nextInt(); // 0이면 가로, 1이면 세로
+            int pos = sc.nextInt(); // 자르는 위치
+
+            if (dir == 0) {
+                horizontalCuts.add(pos);
+            } else {
+                verticalCuts.add(pos);
+            }
+        }
+
+        Collections.sort(horizontalCuts);
+        Collections.sort(verticalCuts);
+
+        int maxArea = 0;
+
+        for (int i = 1; i < horizontalCuts.size(); i++) {
+            int h = horizontalCuts.get(i) - horizontalCuts.get(i - 1);
+            for (int j = 1; j < verticalCuts.size(); j++) {
+                int w = verticalCuts.get(j) - verticalCuts.get(j - 1);
+                int area = w * h;
+                if (area > maxArea) {
+                    maxArea = area;
+                }
+            }
+        }
+
+        System.out.println(maxArea);
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [종이자르기](https://www.acmicpc.net/problem/2628)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 가로·세로 절단선을 정렬한 뒤 인접한 절단선 간의 길이를 계산한다.
- 모든 조각의 넓이를 구해 그중 가장 큰 넓이를 출력한다.

### ⏰ 수행 시간
- 30분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/d1a4e6de-75ab-4dfc-8fb2-eecdf95f423e)

### ✅ 시간 복잡도
- O(N^2)

## 💬 코드 리뷰 요청 사항
- 내일 시험 화이팅입니다!!
