### PR TITLE
[feat] 백준 14696 딱지놀이 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/LYW/D2025_05_02_백준14696_딱지놀이.java
+++ b/src/Algorithm_Study/daily/LYW/D2025_05_02_백준14696_딱지놀이.java
@@ -1,0 +1,43 @@
+package Algorithm_Study.daily.LYW;
+
+import java.util.Scanner;
+
+public class D2025_05_02_백준14696_딱지놀이 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        int rounds = sc.nextInt(); // 라운드 수
+
+        for (int i = 0; i < rounds; i++) {
+            int[] a = new int[5]; // A 플레이어의 도형 개수 (인덱스 1~4 사용)
+            int[] b = new int[5]; // B 플레이어의 도형 개수 (인덱스 1~4 사용)
+
+            int aCount = sc.nextInt();
+            for (int j = 0; j < aCount; j++) {
+                int shape = sc.nextInt();
+                a[shape]++;
+            }
+
+            int bCount = sc.nextInt();
+            for (int j = 0; j < bCount; j++) {
+                int shape = sc.nextInt();
+                b[shape]++;
+            }
+
+            // 도형 우선순위: 4 > 3 > 2 > 1
+            char result = 'D'; // 기본값 무승부
+            for (int shape = 4; shape >= 1; shape--) {
+                if (a[shape] > b[shape]) {
+                    result = 'A';
+                    break;
+                } else if (a[shape] < b[shape]) {
+                    result = 'B';
+                    break;
+                }
+            }
+            System.out.println(result);
+        }
+
+        sc.close();
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [딱지놀이](https://www.acmicpc.net/problem/14696)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 각 라운드마다 두 플레이어가 낸 도형의 개수를 도형 우선순위에 따라 배열에 저장합니다.
- 도형 우선순위대로 개수를 비교하여 더 많이 낸 사람이 이기고, 같으면 무승부로 처리합니다.

### ⏰ 수행 시간
- 50분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/5acb8753-8913-426e-89a4-232ace2f09c8)

### ✅ 시간 복잡도
- O(n)

## 💬 코드 리뷰 요청 사항
- 연휴 잘보내세요~~
