### PR TITLE
[SJG] #0020 퍼즐게임 챌린지 문제 풀이

### DIFF
--- a/src/Algorithm_Study/common/C20250506/SJG.java
+++ b/src/Algorithm_Study/common/C20250506/SJG.java
@@ -1,0 +1,33 @@
+package Algorithm_Study.common.C20250506;
+
+public class SJG {
+	public int solution(int[] diffs, int[] times, long limit) {
+        int maxDiff = 0;
+        // maxDiff값을 diffs배열의 최대값으로 갱신
+        for(int d : diffs) maxDiff = maxDiff > d ? maxDiff : d;
+        
+        int left = 1;
+        int right = maxDiff;
+        while(left < right) {
+            int mid = (left + right) / 2;
+            long total = 0;
+            int prev = 0;
+            
+            for(int i = 0; i < diffs.length; i++) {
+                int curr = times[i];
+                if(mid >= diffs[i]) total += curr;
+                else {
+                    int chance =  diffs[i] - mid;
+                    total += chance * (prev + curr) + curr;
+                    if(total > limit) break;
+                }
+                prev = curr;
+            }
+            
+            if(total <= limit) right = mid;
+            else left = mid + 1;
+        }
+        
+        return left;
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [퍼즐게임 챌린지](https://school.programmers.co.kr/learn/courses/30/lessons/340212)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 가장 낮은 숙련도를 1, 그리고 diffs배열의 가장 큰 값을 가장 높은 숙련도로 설정하여 이분탐색으로 풀었습니다.

### ⏰ 수행 시간
- 50분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/e9730918-1ee0-4ae3-aeb8-e1c133dbee0f)


### ✅ 시간 복잡도
- O(N log M)

## 💬 코드 리뷰 요청 사항
- 문제 읽는게 더 오래걸렸네요.. 사실 그냥 이해못하고 대충 풀었음..
- 입출력 예. 여기 부분보고 여차저차 풀긴했는데 다시봐도 잘 모르겠어요..