### PR TITLE
[CSY] #0020 PCCP 퍼즐 게임 챌린지 문제풀이

### DIFF
--- a/src/Algorithm_Study/common/C20250506/CSY.java
+++ b/src/Algorithm_Study/common/C20250506/CSY.java
@@ -1,0 +1,57 @@
+package Algorithm_Study.common.C20250506;
+
+
+public class CSY {
+
+    public static void main(String[] args) {
+        int[] diffs = {1, 99999, 100000, 99995};
+        int[] times = {9999, 9001, 9999, 9001};
+        int a = solution(diffs, times, 3456789012L);
+        System.out.println(a);
+
+    }
+
+    public static int answer(int[] diffs, int[] times, long limit) {
+        int answer = -1;
+        int left = 1;
+        int right = 100000;
+
+        while(left <= right) {
+            int mid = (left + right) / 2;
+            long time = solution(diffs, times, mid);
+            if(mid <= time) {
+                answer = mid;
+                right = mid + 1;
+            }else {
+                left = mid + 1;
+            }
+        }
+
+        return answer;
+    }
+
+    public static int solution(int[] diffs, int[] times, long limit) {
+
+        //숙련도의 최솟값을 구해야 함.
+        int level = 1;
+        while(true){
+            long time = times[0];
+            f: for(int i = 1; i < diffs.length; i++){
+                if(diffs[i] <= level){
+                    time += times[i];
+                }else{
+                    long cnt = diffs[i] - level;
+                    time += (times[i-1] + times[i]) * cnt + times[i];
+                }
+
+                if(time > limit) break f;
+            }
+            if(time <= limit) return level;
+            level++;
+        }
+
+    }
+
+
+}
+


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [퍼즐 게임 챌린지](https://school.programmers.co.kr/learn/courses/30/lessons/340212)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 문제에 나온대로 구현해서 풀었습니다.
- 이렇게만 풀면...시간초과가 떠서 이분탐색으로 레벨의 범위를 줄여서 풀었습니다.

### ⏰ 수행 시간
- 2시간 30분

### 🤙 시간 인증
<img width="550" alt="image" src="https://github.com/user-attachments/assets/02f0ef31-0bbe-423e-8296-61c47b84ab8c" />

### ✅ 시간 복잡도
-O(NlogM)

## 💬 코드 리뷰 요청 사항
- 처음에 완전탐색으로 풀다가..시간 초과가 떠서,,, 결국 지피티의 도움으로 이분탐색으로 풀었습니다,,ㅜ 
- 요즘 제일 많이 만나는 에러(?)가 시간 초과인 것 같아요,,, 
