### PR TITLE
[feat] SWEA 회문2 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/LYW/D2025_05_06_SWEA_회문2.java
+++ b/src/Algorithm_Study/daily/LYW/D2025_05_06_SWEA_회문2.java
@@ -1,0 +1,74 @@
+package Algorithm_Study.daily.LYW;
+
+import java.util.Scanner;
+
+public class D2025_05_06_SWEA_회문2 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int T = 10;
+
+		for (int test_case = 1; test_case <= T; test_case++) {
+			int tc = sc.nextInt();
+			char[][] arr = new char[100][100];
+
+			for (int i = 0; i < 100; i++) {
+				String line = sc.next();
+				for (int j = 0; j < 100; j++) {
+					arr[i][j] = line.charAt(j);
+				}
+			}
+
+			int maxLen = 0;
+
+			// 가로 탐색
+			for (int i = 0; i < 100; i++) {
+				for (int len = 100; len >= 1; len--) {
+					for (int j = 0; j <= 100 - len; j++) {
+						if (isPalindromeRow(arr, i, j, len)) {
+							maxLen = Math.max(maxLen, len);
+							break; // 더 긴 회문은 없으므로 다음 줄로
+						}
+					}
+					if (maxLen == len)
+						break; // 이미 최대 길이 발견
+				}
+			}
+
+			// 세로 탐색
+			for (int j = 0; j < 100; j++) {
+				for (int len = 100; len >= 1; len--) {
+					for (int i = 0; i <= 100 - len; i++) {
+						if (isPalindromeCol(arr, i, j, len)) {
+							maxLen = Math.max(maxLen, len);
+							break;
+						}
+					}
+					if (maxLen == len)
+						break;
+				}
+			}
+
+			System.out.println("#" + tc + " " + maxLen);
+		}
+	}
+
+	// 가로 회문 확인
+	static boolean isPalindromeRow(char[][] arr, int row, int start, int len) {
+		for (int k = 0; k < len / 2; k++) {
+			if (arr[row][start + k] != arr[row][start + len - 1 - k]) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// 세로 회문 확인
+	static boolean isPalindromeCol(char[][] arr, int start, int col, int len) {
+		for (int k = 0; k < len / 2; k++) {
+			if (arr[start + k][col] != arr[start + len - 1 - k][col]) {
+				return false;
+			}
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [회문2](https://swexpertacademy.com/main/talk/solvingClub/problemView.do?solveclubId=AZTYkRRKItzHBIQp&contestProbId=AV14Rq5aABUCFAYi&probBoxId=AZT3cc66MKDHBIOK&type=PROBLEM&problemBoxTitle=+Day04+String&problemBoxCnt=3)

## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 100×100 배열에서 모든 가로/세로 구간을 길이 100부터 1까지 탐색하면서 회문 여부를 검사한다.
- 가장 먼저 발견된 최대 길이의 회문을 저장하고 출력한다.

### ⏰ 수행 시간
- 30분

### 🤙 시간 인증
![image](https://github.com/user-attachments/assets/29677281-05e6-436c-a2c7-7d6abadfd67f)

### ✅ 시간 복잡도
- O(N² × N)

## 💬 코드 리뷰 요청 사항
- 회문 연습해봤습니다 벌써 연휴가 지나갔네요..
