### PR TITLE
[PJE] 프로그래머스 완주하지못한선수 문제풀이

### DIFF
--- a/src/Algorithm_Study/daily/PJE/D202510/D20251017.java
+++ b/src/Algorithm_Study/daily/PJE/D202510/D20251017.java
@@ -1,0 +1,28 @@
+package Algorithm_Study.daily.PJE.D202510;
+import java.util.*;
+
+//프로그래머스 완주하지 못한 선수
+public class D20251017 {
+    public String solution(String[] participant, String[] completion) {
+        HashMap<String, Integer> map = new HashMap<>();
+
+        // 참가자 명단 저장
+        for (String p : participant) {
+            map.put(p, map.getOrDefault(p, 0) + 1);
+        }
+
+        // 완주자 명단 빼기
+        for (String c : completion) {
+            map.put(c, map.get(c) - 1);
+        }
+
+        // 값이 0이 아닌 선수가 미완주자
+        for (String key : map.keySet()) {
+            if (map.get(key) != 0) {
+                return key;
+            }
+        }
+
+        return null; 
+    }
+}


### PR DESCRIPTION
## 📌 문제 제목
- 문제 링크: [완주하지못한선수](https://school.programmers.co.kr/learn/courses/30/lessons/42576#)
## ✍️ 문제 풀이
### 💡 아이디어 및 접근 방법
- 해시맵 이용해서 참가자 명단을 key로, value는 1로 저장했습니다 (동명이인은 2)
- 완주자는 value를 0으로 만들고,0이 아닌 key값을 완주하지 못한 참가자로 return 했습미다

### ⏰ 수행 시간
- 30분

### 🤙 시간 인증
- 
<img width="787" height="208" alt="image" src="https://github.com/user-attachments/assets/49f064d2-3918-48ad-a623-464dc94d9eaa" />


### ✅ 시간 복잡도
- O(n)

## 💬 코드 리뷰 요청 사항
-
